### PR TITLE
check the version of CLI and build.zig.zon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Check tests
         run: deno task test
-      - name: Check build
-        run: deno task build
+      - name: Check release
+        run: deno task release:check
 
   lint:
     runs-on: ubuntu-latest

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,7 @@
     "fmt:check": "zig fmt . --check && deno fmt --check",
     "build": "zig build -Dtarget=x86_64-windows-msvc -Doptimize=ReleaseSmall",
     "release": "deno task build && deno run --allow-run -RWE release.ts",
+    "release:check": "deno task release --dry-run",
     "check:hash": "certutil -hashfile dist/rb-x86_64-pc-windows-msvc.zip SHA256"
   },
   "imports": {

--- a/release.ts
+++ b/release.ts
@@ -14,6 +14,12 @@ if (version !== buildZigZon.version) {
   );
 }
 
+// If --dry-run is passed, exit
+if (Deno.args.includes("--dry-run")) {
+  console.log("Dry run mode: skipping build and zip.");
+  Deno.exit(0);
+}
+
 // create dist directory
 await Deno.mkdir("dist", { recursive: true });
 // zip the binary


### PR DESCRIPTION
To avoid different versions of CLI and build.zig.zon, check that they are the same in the release script.