### PR TITLE
update to zig v0.16.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
-          version: 0.15.2
+          version: 0.16.0
       - name: Setup Deno
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
-          version: 0.15.2
+          version: 0.16.0
       - name: Setup Deno
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .zig-cache
 zig-out
+zig-pkg
 dist

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,16 +1,16 @@
 .{
     .name = .rb,
     .version = "0.4.0",
-    .minimum_zig_version = "0.15.0",
+    .minimum_zig_version = "0.16.0",
     .fingerprint = 0xff6c09ff26628417,
     .dependencies = .{
         .clap = .{
-            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.11.0.tar.gz",
-            .hash = "clap-0.11.0-oBajB-HnAQDPCKYzwF7rO3qDFwRcD39Q0DALlTSz5H7e",
+            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.12.0.tar.gz",
+            .hash = "clap-0.12.0-oBajB7foAQDqlSwaSG5g0yq7xGbQARUsBk5T64gAOqP5",
         },
         .zigwin32 = .{
-            .url = "git+https://github.com/marlersoft/zigwin32.git#5587b16fa040573846a6bf531301f6206d31a6bf",
-            .hash = "zigwin32-25.0.28-preview-AAAAAICM5AMResOGQnQ85mfe60TTOQeMtt7GRATUOKoP",
+            .url = "git+https://github.com/marlersoft/zigwin32.git#9f15c276b4e9d05afd34a10d8662a7dfc34647ea",
+            .hash = "win32-42.0.39-preview-mX5pFS564gPTezZn4v3TMxRnfJUrZNx1B_F2p2HKXOeG",
         },
     },
     .paths = .{

--- a/deno.json
+++ b/deno.json
@@ -2,8 +2,8 @@
   "tasks": {
     "run": "deno task build && zig-out/bin/rb.exe",
     "test": "zig build test",
-    "fmt": "zig fmt . && deno fmt",
-    "fmt:check": "zig fmt . --check && deno fmt --check",
+    "fmt": "zig fmt build.zig build.zig.zon src scripts",
+    "fmt:check": "zig fmt build.zig build.zig.zon src scripts --check",
     "build": "zig build -Dtarget=x86_64-windows-msvc -Doptimize=ReleaseSmall",
     "release": "zig build release",
     "check:hash": "certutil -hashfile dist/rb-x86_64-pc-windows-msvc.zip SHA256"

--- a/scripts/release.zig
+++ b/scripts/release.zig
@@ -1,16 +1,14 @@
 const std = @import("std");
-const fs = std.fs;
 const process = std.process;
-const io = std.io;
 const json = std.json;
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+    const cwd = std.Io.Dir.cwd();
 
     // Read build.zig.zon
-    const build_zon_content = try fs.cwd().readFileAlloc(allocator, "build.zig.zon", 1024 * 1024);
+    const build_zon_content = try cwd.readFileAlloc(io, "build.zig.zon", allocator, .limited(1024 * 1024));
     defer allocator.free(build_zon_content);
 
     // Parse version from build.zig.zon
@@ -18,28 +16,30 @@ pub fn main() !void {
     defer allocator.free(version);
 
     // Write version.zon
-    try writeVersionZon(allocator, version);
+    try writeVersionZon(io, allocator, version);
 
     // Format version.zon
-    try formatVersionZon(allocator);
+    try formatVersionZon(io);
 
     // Create dist directory
-    try fs.cwd().makePath("dist");
+    try cwd.createDirPath(io, "dist");
 
     // Build and compress for x86_64
     std.debug.print("Building x86_64-windows-msvc...\n", .{});
-    try buildProject(allocator, "x86_64-windows-msvc");
-    try compressBinary(allocator, "x86_64-pc-windows-msvc");
-    const x64_hash = try calculateHash(allocator, "dist/rb-x86_64-pc-windows-msvc.zip");
+    const x64_prefix = "zig-out/release/x86_64-windows-msvc";
+    try buildProject(io, allocator, "x86_64-windows-msvc", x64_prefix);
+    try compressBinary(io, allocator, x64_prefix, "x86_64-pc-windows-msvc");
+    const x64_hash = try calculateHash(io, allocator, "dist/rb-x86_64-pc-windows-msvc.zip");
 
     // Build and compress for aarch64
     std.debug.print("Building aarch64-windows-msvc...\n", .{});
-    try buildProject(allocator, "aarch64-windows-msvc");
-    try compressBinary(allocator, "aarch64-pc-windows-msvc");
-    const arm64_hash = try calculateHash(allocator, "dist/rb-aarch64-pc-windows-msvc.zip");
+    const arm64_prefix = "zig-out/release/aarch64-windows-msvc";
+    try buildProject(io, allocator, "aarch64-windows-msvc", arm64_prefix);
+    try compressBinary(io, allocator, arm64_prefix, "aarch64-pc-windows-msvc");
+    const arm64_hash = try calculateHash(io, allocator, "dist/rb-aarch64-pc-windows-msvc.zip");
 
     // Generate scoop manifest
-    try generateScoopManifest(allocator, version, x64_hash, arm64_hash);
+    try generateScoopManifest(io, allocator, version, x64_hash, arm64_hash);
 
     std.debug.print("✅ Release preparation completed successfully\n", .{});
 }
@@ -54,22 +54,22 @@ fn parseVersion(allocator: std.mem.Allocator, content: []const u8) ![]u8 {
     return allocator.dupe(u8, version);
 }
 
-fn writeVersionZon(allocator: std.mem.Allocator, version: []const u8) !void {
+fn writeVersionZon(io: std.Io, allocator: std.mem.Allocator, version: []const u8) !void {
     const version_content = try std.fmt.allocPrint(allocator, ".{{ .version = \"{s}\" }}\n", .{version});
     defer allocator.free(version_content);
 
-    const file = try fs.cwd().createFile("src/version.zon", .{});
-    defer file.close();
-    try file.writeAll(version_content);
+    try std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = "src/version.zon",
+        .data = version_content,
+    });
 }
 
-fn formatVersionZon(allocator: std.mem.Allocator) !void {
+fn formatVersionZon(io: std.Io) !void {
     const argv = [_][]const u8{ "zig", "fmt", "src/version.zon" };
-    var child = std.process.Child.init(&argv, allocator);
-    _ = try child.spawnAndWait();
+    try runCommand(io, &argv);
 }
 
-fn buildProject(allocator: std.mem.Allocator, target: []const u8) !void {
+fn buildProject(io: std.Io, allocator: std.mem.Allocator, target: []const u8, prefix: []const u8) !void {
     const target_arg = try std.fmt.allocPrint(allocator, "-Dtarget={s}", .{target});
     defer allocator.free(target_arg);
 
@@ -78,30 +78,41 @@ fn buildProject(allocator: std.mem.Allocator, target: []const u8) !void {
         "build",
         target_arg,
         "-Doptimize=ReleaseSmall",
+        "--prefix",
+        prefix,
     };
-    var child = std.process.Child.init(&argv, allocator);
-    _ = try child.spawnAndWait();
+    try runCommand(io, &argv);
 }
 
-fn compressBinary(allocator: std.mem.Allocator, target: []const u8) !void {
+fn compressBinary(io: std.Io, allocator: std.mem.Allocator, prefix: []const u8, target: []const u8) !void {
     const dest_path = try std.fmt.allocPrint(allocator, "dist/rb-{s}.zip", .{target});
     defer allocator.free(dest_path);
+    const binary_path = try std.fmt.allocPrint(allocator, "{s}/bin/rb.exe", .{prefix});
+    defer allocator.free(binary_path);
 
     const argv = [_][]const u8{
         "powershell",
         "Compress-Archive",
         "-Path",
-        "zig-out/bin/rb.exe",
+        binary_path,
         "-DestinationPath",
         dest_path,
         "-Force",
     };
-    var child = std.process.Child.init(&argv, allocator);
-    _ = try child.spawnAndWait();
+    try runCommand(io, &argv);
 }
 
-fn calculateHash(allocator: std.mem.Allocator, zip_path: []const u8) ![std.crypto.hash.sha2.Sha256.digest_length * 2]u8 {
-    const zip_data = try fs.cwd().readFileAlloc(allocator, zip_path, 100 * 1024 * 1024);
+fn runCommand(io: std.Io, argv: []const []const u8) !void {
+    var child = try process.spawn(io, .{ .argv = argv });
+    const term = try child.wait(io);
+    switch (term) {
+        .exited => |code| if (code != 0) return error.ChildProcessFailed,
+        else => return error.ChildProcessFailed,
+    }
+}
+
+fn calculateHash(io: std.Io, allocator: std.mem.Allocator, zip_path: []const u8) ![std.crypto.hash.sha2.Sha256.digest_length * 2]u8 {
+    const zip_data = try std.Io.Dir.cwd().readFileAlloc(io, zip_path, allocator, .limited(100 * 1024 * 1024));
     defer allocator.free(zip_data);
 
     // Calculate SHA-256 hash
@@ -112,7 +123,7 @@ fn calculateHash(allocator: std.mem.Allocator, zip_path: []const u8) ![std.crypt
     return std.fmt.bytesToHex(hash, .lower);
 }
 
-fn generateScoopManifest(allocator: std.mem.Allocator, version: []const u8, x64_hash: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8, arm64_hash: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8) !void {
+fn generateScoopManifest(io: std.Io, allocator: std.mem.Allocator, version: []const u8, x64_hash: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8, arm64_hash: [std.crypto.hash.sha2.Sha256.digest_length * 2]u8) !void {
     const x64_url = try std.fmt.allocPrint(allocator, "https://github.com/ryuapp/rb/releases/download/v{s}/rb-x86_64-pc-windows-msvc.zip", .{version});
     defer allocator.free(x64_url);
 
@@ -150,7 +161,8 @@ fn generateScoopManifest(allocator: std.mem.Allocator, version: []const u8, x64_
     const manifest_str = try std.fmt.allocPrint(allocator, "{f}\n", .{json.fmt(manifest, .{ .whitespace = .indent_2 })});
     defer allocator.free(manifest_str);
 
-    const file = try fs.cwd().createFile("rb.json", .{});
-    defer file.close();
-    try file.writeAll(manifest_str);
+    try std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = "rb.json",
+        .data = manifest_str,
+    });
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,9 +11,10 @@ const VersionStruct = struct {
 };
 const RbVersion: VersionStruct = @import("version.zon");
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     try Output.init();
-    const alc = std.heap.page_allocator;
+    const alc = init.gpa;
+    const io = init.io;
 
     const params = comptime clap.parseParamsComptime(
         \\-f, --force           Ignore nonexistent files and arguments, never prompt
@@ -23,12 +24,12 @@ pub fn main() !void {
         \\<str>...              Put FILE(s) and DIRECTORY(ies) in the recycle bin.
     );
 
-    var res = clap.parse(clap.Help, &params, clap.parsers.default, .{
+    var res = clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{
         .allocator = alc,
     }) catch {
-        const stderr = std.fs.File.stderr();
+        const stderr = std.Io.File.stderr();
         var buffer: [4096]u8 = undefined;
-        var writer = stderr.writer(&buffer);
+        var writer = stderr.writer(io, &buffer);
         try writer.interface.print("rb: cannot be executed: Invalid arguments\n", .{});
         try writer.interface.flush();
         Output.restore();
@@ -48,9 +49,9 @@ pub fn main() !void {
             \\  -h, --help            Display this help
             \\      --version         Display version information
         ;
-        const stderr = std.fs.File.stderr();
+        const stderr = std.Io.File.stderr();
         var buffer: [4096]u8 = undefined;
-        var writer = stderr.writer(&buffer);
+        var writer = stderr.writer(io, &buffer);
         try writer.interface.print("{s}\n", .{help_message});
         try writer.interface.flush();
         Output.restore();
@@ -62,9 +63,9 @@ pub fn main() !void {
         const message =
             \\rb {s}
         ;
-        const stderr = std.fs.File.stderr();
+        const stderr = std.Io.File.stderr();
         var buffer: [4096]u8 = undefined;
-        var writer = stderr.writer(&buffer);
+        var writer = stderr.writer(io, &buffer);
         try writer.interface.print(message, .{RbVersion.version});
         try writer.interface.flush();
         Output.restore();
@@ -73,9 +74,9 @@ pub fn main() !void {
 
     // No arguments
     if (res.positionals[0].len == 0) {
-        const stderr = std.fs.File.stderr();
+        const stderr = std.Io.File.stderr();
         var buffer: [4096]u8 = undefined;
-        var writer = stderr.writer(&buffer);
+        var writer = stderr.writer(io, &buffer);
         try writer.interface.print("rb: missing operand\nTry 'rb --help' for more information\n", .{});
         try writer.interface.flush();
         Output.restore();
@@ -85,12 +86,12 @@ pub fn main() !void {
     const verbose = res.args.verbose != 0;
     const force = res.args.force != 0;
 
-    const stderr = std.fs.File.stderr();
+    const stderr = std.Io.File.stderr();
     var buffer: [4096]u8 = undefined;
-    var stderr_writer = stderr.writer(&buffer);
+    var stderr_writer = stderr.writer(io, &buffer);
 
     for (res.positionals[0]) |filename| {
-        const result = try trash.trash(alc, filename);
+        const result = try trash.trash(io, alc, filename);
         // If --force is enabled and file doesn't exist (error code 2) on Windows, ignore it
         if (force and ((comptime builtin.os.tag == .windows) and result == 2)) {
             continue;

--- a/src/output.zig
+++ b/src/output.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const zigwin32 = @import("zigwin32");
 
-const win = std.os.windows;
-const k32 = win.kernel32;
+const console = zigwin32.system.console;
+const k32 = zigwin32.kernel32;
 
 const is_windows = builtin.os.tag == .windows;
 
@@ -24,17 +25,19 @@ const WindowsOutput = struct {
     // Make a console output code is the same as before execution
     fn setAbortSignalHandler(comptime handler: *const fn () void) !void {
         const handler_routine = struct {
-            fn handler_routine(dwCtrlType: win.DWORD) callconv(std.builtin.CallingConvention.winapi) win.BOOL {
-                if (dwCtrlType == win.CTRL_C_EVENT) {
+            fn handler_routine(dwCtrlType: u32) callconv(.winapi) i32 {
+                if (dwCtrlType == console.CTRL_C_EVENT) {
                     handler();
-                    return win.TRUE;
+                    return 1;
                 } else {
-                    return win.FALSE;
+                    return 0;
                 }
             }
         }.handler_routine;
 
-        try win.SetConsoleCtrlHandler(handler_routine, true);
+        if (k32.SetConsoleCtrlHandler(handler_routine, 1) == 0) {
+            return error.SetConsoleCtrlHandlerFailed;
+        }
     }
     fn abortSignalHandler() void {
         restore();

--- a/src/trash.zig
+++ b/src/trash.zig
@@ -4,9 +4,9 @@ const windows = @import("windows_trash.zig");
 
 const is_windows = builtin.os.tag == .windows;
 
-pub fn trash(allocator: std.mem.Allocator, filename: []const u8) !i32 {
+pub fn trash(io: std.Io, allocator: std.mem.Allocator, filename: []const u8) !i32 {
     return switch (builtin.os.tag) {
-        .windows => windows.trash(allocator, filename),
+        .windows => windows.trash(io, allocator, filename),
         else => error.UnsupportedPlatform,
     };
 }
@@ -19,22 +19,30 @@ pub fn getErrorMessage(allocator: std.mem.Allocator, error_code: i32) ![]const u
 }
 
 test "trash file" {
-    const filename = "test.txt";
-    _ = try std.fs.cwd().createFile(
-        filename,
-        .{ .read = true },
-    );
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
 
-    const result = try trash(std.testing.allocator, filename);
+    const filename = "test.txt";
+    const file = try tmp.dir.createFile(std.testing.io, filename, .{ .read = true });
+    file.close(std.testing.io);
+    const absolute_path = try tmp.dir.realPathFileAlloc(std.testing.io, filename, std.testing.allocator);
+    defer std.testing.allocator.free(absolute_path);
+
+    const result = try trash(std.testing.io, std.testing.allocator, absolute_path);
 
     try std.testing.expect(result == 0);
 }
 
 test "trash directory" {
-    const directory_name = "TestDir";
-    try std.fs.cwd().makeDir(directory_name);
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
 
-    const result = try trash(std.testing.allocator, directory_name);
+    const directory_name = "TestDir";
+    try tmp.dir.createDir(std.testing.io, directory_name, .default_dir);
+    const absolute_path = try tmp.dir.realPathFileAlloc(std.testing.io, directory_name, std.testing.allocator);
+    defer std.testing.allocator.free(absolute_path);
+
+    const result = try trash(std.testing.io, std.testing.allocator, absolute_path);
 
     try std.testing.expect(result == 0);
 }

--- a/src/windows_trash.zig
+++ b/src/windows_trash.zig
@@ -5,7 +5,9 @@ const com = zigwin32.system.com;
 const shell = zigwin32.ui.shell;
 const foundation = zigwin32.foundation;
 const debug = zigwin32.system.diagnostics.debug;
-const memory = zigwin32.system.memory;
+const kernel32 = zigwin32.kernel32;
+const ole32 = zigwin32.ole32;
+const shell32 = zigwin32.shell32;
 
 const IShellItem = shell.IShellItem;
 const IFileOperation = shell.IFileOperation;
@@ -15,13 +17,13 @@ const CLSID_FileOperation = shell.CLSID_FileOperation;
 const CLSCTX_ALL = com.CLSCTX_ALL;
 const COINIT_MULTITHREADED = com.COINIT_MULTITHREADED;
 
-const CoUninitialize = com.CoUninitialize;
-const CoInitializeEx = com.CoInitializeEx;
-const CoCreateInstance = com.CoCreateInstance;
-const SHCreateItemFromParsingName = shell.SHCreateItemFromParsingName;
+const CoUninitialize = ole32.CoUninitialize;
+const CoInitializeEx = ole32.CoInitializeEx;
+const CoCreateInstance = ole32.CoCreateInstance;
+const SHCreateItemFromParsingName = shell32.SHCreateItemFromParsingName;
 
-const FormatMessageW = debug.FormatMessageW;
-const LocalFree = memory.LocalFree;
+const FormatMessageW = kernel32.FormatMessageW;
+const LocalFree = kernel32.LocalFree;
 
 // Operation Flags
 // See: https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifileoperation-setoperationflags
@@ -41,30 +43,30 @@ fn getFileOperation() !*IFileOperation {
         IID_IFileOperation,
         @ptrCast(&file_op),
     );
-    if (hr != 0) return error.CoCreateInstanceFailed;
+    if (hr.failed) return error.CoCreateInstanceFailed;
     return file_op;
 }
 
 fn getShellItem(filename: [:0]u16) !*IShellItem {
     var shell_item: *IShellItem = undefined;
     const result = SHCreateItemFromParsingName(filename, null, IID_IShellItem, @ptrCast(&shell_item));
-    if (result != 0) return error.CreateItemFailed;
+    if (result.failed) return error.CreateItemFailed;
     return shell_item;
 }
 
-pub fn trash(allocator: std.mem.Allocator, filename: []const u8) !i32 {
+pub fn trash(io: std.Io, allocator: std.mem.Allocator, filename: []const u8) !i32 {
     // Initialize the COM Library
     // See: https://learn.microsoft.com/en-us/windows/win32/learnwin32/initializing-the-com-library
     const hr_init = CoInitializeEx(null, COINIT_MULTITHREADED);
     defer CoUninitialize();
-    if (hr_init != 0) return error.CoInitializeFailed;
+    if (hr_init.failed) return error.CoInitializeFailed;
 
     var file_op = getFileOperation() catch |err| {
         return err;
     };
     const operation_flags = FOF_SILENT | FOF_NOERRORUI | FOF_NOCONFIRMATION | FOFX_ADDUNDORECORD | FOFX_EARLYFAILURE | FOFX_RECYCLEONDELETE;
     _ = file_op.SetOperationFlags(operation_flags);
-    const realpath = std.fs.cwd().realpathAlloc(allocator, filename) catch |err| {
+    const realpath = std.Io.Dir.cwd().realPathFileAlloc(io, filename, allocator) catch |err| {
         if (err == error.FileNotFound) {
             return 2;
         }
@@ -84,7 +86,7 @@ pub fn trash(allocator: std.mem.Allocator, filename: []const u8) !i32 {
     return switch (result) {
         zigwin32.foundation.E_ACCESSDENIED => 5,
         shell.COPYENGINE_E_SHARING_VIOLATION_SRC => 32,
-        else => result,
+        else => @bitCast(result),
     };
 }
 


### PR DESCRIPTION
Update rb to support Zig 0.16.0, including zig-clap 0.12.0 and the new I/O APIs.